### PR TITLE
a11y: add aria attributes to stars background

### DIFF
--- a/src/components/widgets/Stars.astro
+++ b/src/components/widgets/Stars.astro
@@ -14,7 +14,7 @@ const stars = [
   {/* Main content with stars */}
   <div class="relative w-full min-h-screen overflow-hidden dark:bg-gradient-to-b from-black via-page to-black">
     {/* Stars background layer */}
-    <div class="absolute inset-0 z-0 overflow-hidden">
+    <div class="absolute inset-0 z-0 overflow-hidden" aria-hidden="true" role="presentation">
       {
         stars.map((star) => (
           <div


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Added accessibility attributes to the stars background component to improve screen reader experience

### What changed?
Added `aria-hidden="true"` and `role="presentation"` to the stars background div to properly hide decorative content from screen readers

## 📌 Additional Notes
This change enhances accessibility by preventing screen readers from announcing purely decorative star animations

## 🔗 Related Issues
🔄 Closes #
- 

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 Style/UI update

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing