### PR TITLE
feat: add infographics support and header customization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,5 @@
   },
   "vim.useSystemClipboard": true,
   "eslint.useFlatConfig": true,
-  "cSpell.words": ["Funders", "urfit"]
+  "cSpell.words": ["Funders", "Infographics", "urfit"]
 }

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -6,8 +6,10 @@ import Button from '~/components/ui/Button.astro';
 import AnimatedChildSvg from '~/components/widgets/AnimatedChildSvg.astro';
 import type { CallToAction } from '~/types';
 import { getHomePermalink, getPermalink, trimSlash } from '~/utils/permalinks';
+import type { ImageMetadata } from 'astro';
 import { Icon } from 'astro-icon/components';
 import { Image } from 'astro:assets';
+import { twMerge } from 'tailwind-merge';
 
 // import LanguagePicker from '../common/LanguagePicker.astro';
 // import { getLangFromUrl, useTranslations } from '~/i18n/utils';
@@ -18,7 +20,7 @@ interface Link {
   ariaLabel?: string;
   icon?: string;
   image?: {
-    src: string;
+    src: ImageMetadata;
     alt: string;
   };
 }
@@ -30,6 +32,7 @@ interface MenuLink extends Link {
 export interface Props {
   id?: string;
   links?: Array<MenuLink>;
+  classes?: Record<string, string>;
   actions?: Array<CallToAction>;
   isSticky?: boolean;
   isDark?: boolean;
@@ -51,11 +54,14 @@ const {
   // showLangPicker = true,
   // showRssFeed = false,
   position = 'center',
+  classes = {},
 } = Astro.props;
 
 const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
 // const lang = getLangFromUrl(Astro.url);
 // const t = useTranslations(lang);
+
+const { nav: navClass = '' } = classes;
 ---
 
 <header
@@ -93,7 +99,10 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
       </div>
     </div>
     <nav
-      class="items-center w-full lg:w-auto hidden lg:flex lg:mx-5 text-default overflow-y-auto overflow-x-hidden lg:overflow-y-visible lg:overflow-x-auto lg:justify-self-center"
+      class={twMerge(
+        navClass,
+        'items-center w-full lg:w-auto hidden lg:flex lg:mx-5 text-default overflow-y-auto overflow-x-hidden lg:overflow-y-visible lg:overflow-x-auto lg:justify-self-center'
+      )}
       aria-label="Main navigation"
     >
       <ul

--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -102,7 +102,7 @@ const { labelContainer: labelContainerClass = '' } = classes;
                           sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
                           loading="eager"
                           width={1024}
-                          height={576}
+                          height={image.isInfographics ? 737 : 576}
                           {...image}
                         />
                       </a>
@@ -114,8 +114,8 @@ const { labelContainer: labelContainerClass = '' } = classes;
                         loading="eager"
                         decoding="async"
                         objectPosition="top top"
-                        width={1024}
-                        height={576}
+                        width={image.isInfographics ? 1080 : 1024}
+                        height={image.isInfographics ? 737 : 576}
                         {...image}
                       />
                     )}

--- a/src/components/widgets/list/InfoGraficsList.astro
+++ b/src/components/widgets/list/InfoGraficsList.astro
@@ -71,8 +71,11 @@ const { columns = 2, classes = {} } = Astro.props;
                         src={item.image.src}
                         alt={item.image.alt}
                         class="w-full h-full object-cover rounded-lg"
-                        width={1024}
-                        height={576}
+                        loading="lazy"
+                        layout="contained"
+                        decoding="async"
+                        width={1080}
+                        height={737}
                       />
                     </div>
                   </div>

--- a/src/components/widgets/principal-investigator/PIHeader.astro
+++ b/src/components/widgets/principal-investigator/PIHeader.astro
@@ -3,6 +3,7 @@ import Header from '~/components/widgets/Header.astro';
 ---
 
 <Header
+  classes={{ nav: 'pl-20 xl:pl-0' }}
   links={[
     { text: 'Description', href: '#' },
     { text: 'Academic', href: '#academic' },

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -9,9 +9,10 @@ import type { MetaData } from '~/types';
 
 export interface Props {
   metadata?: MetaData;
+  classes?: Record<string, string | Record<string, string>>;
 }
 
-const { metadata } = Astro.props;
+const { metadata, classes } = Astro.props;
 ---
 
 <Layout metadata={metadata}>
@@ -19,7 +20,7 @@ const { metadata } = Astro.props;
     <Announcement />
   </slot> -->
   <slot name="header">
-    <Header {...headerData} isSticky showRssFeed showToggleTheme />
+    <Header {...headerData} classes={classes?.header as Record<string, string>} isSticky showRssFeed showToggleTheme />
   </slot>
   <main>
     <slot />

--- a/src/pages/waist-height-calculator.astro
+++ b/src/pages/waist-height-calculator.astro
@@ -163,7 +163,7 @@ const metadata = {
 
   <!-- Hero Widget ******************* -->
 
-  <Hero image={{ src: imgCalculator, alt: 'Waist to Height Ratio vs BMI Press Release' }} />
+  <Hero image={{ src: imgCalculator, alt: 'Waist to Height Ratio vs BMI Press Release', isInfographics: true }} />
 
   <!-- Spacer ******************* -->
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -239,12 +239,14 @@ export interface Form {
 export interface Hero extends Headline, Widget {
   content?: string;
   actions?: string | CallToAction[];
+  isInfographics?: boolean;
   image?:
     | string
     | {
         src: string | ImageMetadata;
         alt?: string;
         class?: string;
+        isInfographics?: boolean;
         link?: {
           href: string;
           target?: string;


### PR DESCRIPTION
# Pull Request

## 📝 Description
Added support for infographics images and improved header navigation styling

### What changed?
- Added `isInfographics` flag to Hero component for proper image sizing
- Implemented custom navigation classes in Header component
- Updated image dimensions for infographics (1080x737)
- Added "Infographics" to VSCode spell check dictionary
- Adjusted header navigation padding for principal investigator page
- Enhanced PageLayout to support custom header classes

## 📌 Additional Notes
The changes improve the display of infographic content while maintaining responsive behavior

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [x] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing