### PR TITLE
fix: adjust dropdown menu top position

### DIFF
--- a/src/components/widgets/HeaderNavigation.astro
+++ b/src/components/widgets/HeaderNavigation.astro
@@ -12,7 +12,7 @@ const { links, currentPath } = Astro.props;
 ---
 
 <div
-  class="dropdown-menu absolute top-[58px] lg:left-[25%] xl:left-[27%] 2xl:left-[35%] lg:backdrop-blur-md lg:bg-white/80 dark:lg:bg-[#030621e6]/80 drop-shadow-xl lg:border border-gray-200 dark:border-gray-800 transition-all duration-300 ease-in-out hidden rounded-md"
+  class="dropdown-menu absolute top-[56px] lg:left-[25%] xl:left-[27%] 2xl:left-[35%] lg:backdrop-blur-md lg:bg-white/80 dark:lg:bg-[#030621e6]/80 drop-shadow-xl lg:border border-gray-200 dark:border-gray-800 transition-all duration-300 ease-in-out hidden rounded-md"
   data-navigation-menu
 >
   <div class="w-[440px]">


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Adjusted the dropdown menu positioning by moving it 2px higher for better visual alignment with the header.

### What changed?
Modified the `top` CSS property of the dropdown menu from `58px` to `56px` to achieve better vertical alignment.

## 📌 Additional Notes
This is a minor visual adjustment that improves the UI consistency.

## 🔗 Related Issues
🔄 Closes #
- 

## 🔍 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing