### PR TITLE
fix: improve page transition handling

### DIFF
--- a/src/components/widgets/PressMe.astro
+++ b/src/components/widgets/PressMe.astro
@@ -174,33 +174,38 @@ import WidgetWrapper from '../ui/WidgetWrapper.astro';
 
   function initButton() {
     const button = document.querySelector('#pressMeButton');
-    const videoBackground = document.querySelector('#videoBackground');
-    const downArrow = document.querySelector('.down-arrow');
-    const pressMeContent = document.querySelector('.pressMeContent');
+    if (!button) return;
 
-    if (button && videoBackground && downArrow && pressMeContent) {
-      button.addEventListener('click', () => {
+    // Remove any existing event listeners
+    const newButton = button.cloneNode(true);
+    button.parentNode?.replaceChild(newButton, button);
+
+    // Add new event listener
+    newButton.addEventListener('click', () => {
+      const videoBackground = document.querySelector('#videoBackground');
+      const downArrow = document.querySelector('.down-arrow');
+      const pressMeContent = document.querySelector('.pressMeContent');
+
+      if (videoBackground && downArrow && pressMeContent) {
         videoBackground.classList.remove('opacity-0');
         videoBackground.classList.add('opacity-100');
-        button.classList.add('opacity-0', 'pointer-events-none');
+        (newButton as HTMLElement).classList.add('opacity-0', 'pointer-events-none');
         pressMeContent.classList.remove('hidden');
 
         // Show down arrow after 500ms
-        if (downArrow) {
-          setTimeout(() => {
-            downArrow.classList.add('visible');
-          }, 1400);
-        }
+        setTimeout(() => {
+          downArrow.classList.add('visible');
+        }, 1400);
 
         // Toggle dark mode
         localStorage.theme = 'dark';
         applyTheme('dark');
-      });
-    }
+      }
+    });
   }
 
-  // Initialize navigation when the DOM is ready and after each page navigation
-  function initializeNavigation() {
+  // Initialize when the DOM is ready and after each page navigation
+  function initialize() {
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', initButton);
     } else {
@@ -208,6 +213,18 @@ import WidgetWrapper from '../ui/WidgetWrapper.astro';
     }
   }
 
-  initializeNavigation();
-  document.addEventListener('astro:page-load', initializeNavigation);
+  // Run initialization
+  initialize();
+
+  // Re-initialize after Astro page transitions
+  document.addEventListener('astro:page-load', initialize);
+
+  // Clean up before page transitions
+  document.addEventListener('astro:before-swap', () => {
+    const button = document.querySelector('#pressMeButton');
+    if (button) {
+      const newButton = button.cloneNode(true);
+      button.parentNode?.replaceChild(newButton, button);
+    }
+  });
 </script>

--- a/src/components/widgets/subscribe/ReactSubscribeForm.tsx
+++ b/src/components/widgets/subscribe/ReactSubscribeForm.tsx
@@ -45,8 +45,27 @@ export default function ReactSubscribeForm() {
     };
   }, [formState.status]);
 
+  // Reset form state on page transitions
+  useEffect(() => {
+    const handlePageLoad = () => {
+      setFormState({
+        email: '',
+        status: 'idle',
+        message: '',
+        isVisible: false,
+      });
+    };
+
+    document.addEventListener('astro:page-load', handlePageLoad);
+    return () => {
+      document.removeEventListener('astro:page-load', handlePageLoad);
+    };
+  }, []);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    e.stopPropagation(); // Prevent event bubbling
+    
     setFormState((prev) => ({ ...prev, status: 'loading' }));
 
     try {
@@ -63,7 +82,6 @@ export default function ReactSubscribeForm() {
       }
 
       const workerUrl = 'https://subscribe.juhani-juusola.workers.dev/subscribe';
-      // const workerUrl = import.meta.env.PUBLIC_SUBSCRIBE_API_URL;
 
       const response = await fetch(workerUrl, {
         method: 'POST',


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Improves event handling and state management during Astro page transitions for the PressMe button and Subscribe form components.

### What changed?
- Added proper cleanup of event listeners for the PressMe button during page transitions
- Implemented button cloning to prevent memory leaks and duplicate event listeners
- Added form state reset functionality for the Subscribe form during page transitions
- Prevented event bubbling in the Subscribe form submission handler
- Improved null checks and error handling in button initialization
- Removed commented-out worker URL code

## 📌 Additional Notes
These changes enhance the reliability of interactive components during client-side navigation and prevent potential memory leaks.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactoring

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing