### PR TITLE
fix: update stats widget title text in index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -187,7 +187,7 @@ const metadata = {
   <!-- Stats Widget ****************** -->
 
   <Stats
-    title="With an unique data set, broad findings, and simple solutions, the results speak for themselves"
+    title="Using a unique data set (Children of the 90’s) from the University of Bristol, UK, our findings aim to provide simple solutions that reach the widest audience possible."
     classes={{ container: 'pb-0 md:pb-0 lg:pb-0' }}
     stats={[
       { title: 'Participating families', amount: '14.5K' },


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
Updated the stats widget title text on the homepage to specifically reference the "Children of the 90's" dataset from the University of Bristol, UK, and clarified the purpose of our findings.

### What changed?
Modified the stats widget title to be more specific about the data source and research goals, emphasizing the use of the University of Bristol dataset and our aim to provide widely accessible solutions.

## 📌 Additional Notes
The new text provides more context about the data source and better communicates our research objectives.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🎨 Style/UI update

## ✅ Checklist

### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👀 Manual testing