### PR TITLE
fix: adjust padding in CTA page Steps component

### DIFF
--- a/src/pages/call-to-action.astro
+++ b/src/pages/call-to-action.astro
@@ -12,6 +12,7 @@ const metadata = {
 
 <Layout metadata={metadata}>
   <Steps
+    classes={{ container: 'pb-0 md:pb-0 lg:pb-0' }}
     title="We aim to translate research findings into clinical and public health practice. Below are a few recommendations based on our research."
     items={[
       {


### PR DESCRIPTION
# Pull Request

## 📝 Description
Added padding adjustments to the call-to-action page container for consistent spacing across all viewport sizes.

### What changed?
Modified the container classes in call-to-action.astro to set padding-bottom to 0 across mobile, tablet, and desktop breakpoints.

## 📌 Additional Notes
This change ensures consistent bottom spacing regardless of screen size.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing