### PR TITLE
feat: move 2024 scholar award to 2025 section

### DIFF
--- a/src/data/awardsAndHonours.ts
+++ b/src/data/awardsAndHonours.ts
@@ -13,15 +13,15 @@ export const recentAwards2025: Award[] = [
     location: null,
     icon: 'tabler:quote-filled',
   },
-];
-
-export const recentAwards2024: Award[] = [
   {
     title: "The 2024 World's Third-Best Highly Ranked Scholar",
     subtitle: 'Arterial Stiffness Specialty by ScholarGPS',
     location: null,
     icon: 'tabler:chart-bar',
   },
+];
+
+export const recentAwards2024: Award[] = [
   {
     title: "World's Most Significant Research",
     subtitle: "American Heart Association's 2024 World's Most Significant Advances in Cardiovascular Research",


### PR DESCRIPTION
# Pull Request

## 📝 Description
Moved the "2024 World's Third-Best Highly Ranked Scholar" award from the 2024 section to the 2025 section.

### What changed?
- Relocated the "The 2024 World's Third-Best Highly Ranked Scholar" award entry from `recentAwards2024` array to `recentAwards2025` array
- Repositioned the array closing bracket and opening bracket accordingly to maintain proper structure

## 📌 Additional Notes
This change ensures the award is displayed in the correct chronological section.

## 🔗 Related Issues
🔄 Closes #
- 

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing