### PR TITLE
fix: replace greater-than symbol with greater-than-or-equal symbol in waist-height calculator

### DIFF
--- a/src/pages/waist-height-calculator.astro
+++ b/src/pages/waist-height-calculator.astro
@@ -135,9 +135,9 @@ const metadata = {
         colorClass: 'bg-yellow-500',
         subtitle: { text1: 'Male', text2: 'Female' },
         rows: [
-          { text1: `>${THRESHOLDS.male.high.toFixed(2)}`, text2: `>${THRESHOLDS.female.high.toFixed(2)}` },
-          { text1: `>${THRESHOLDS.male.high.toFixed(2)}`, text2: `>${THRESHOLDS.female.high.toFixed(2)}` },
-          { text1: `>${THRESHOLDS.male.high.toFixed(2)}`, text2: `>${THRESHOLDS.female.high.toFixed(2)}` },
+          { text1: `≥${THRESHOLDS.male.high.toFixed(2)}`, text2: `≥${THRESHOLDS.female.high.toFixed(2)}` },
+          { text1: `≥${THRESHOLDS.male.high.toFixed(2)}`, text2: `≥${THRESHOLDS.female.high.toFixed(2)}` },
+          { text1: `≥${THRESHOLDS.male.high.toFixed(2)}`, text2: `≥${THRESHOLDS.female.high.toFixed(2)}` },
         ],
       },
       {


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fixed incorrect mathematical symbol in waist-height calculator thresholds

### What changed?
- Changed the greater than symbol (`>`) to greater than or equal to (`≥`) in the waist-height ratio threshold display for both male and female categories

## 📌 Additional Notes
This change ensures mathematical accuracy in the threshold representation, which is important for correct interpretation of the waist-height ratio results.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing