### PR TITLE
fix: update header transitions and adjust spacing in materials and people pages

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -41,18 +41,13 @@
 #header.scroll > div:first-child {
   @apply bg-white/80 backdrop-blur-md;
   box-shadow: 0 0.375rem 1.5rem 0 rgb(140 152 164 / 13%);
-  @apply border-b border-transparent;
-  /* transition:
-    border-color 0.3s ease-in-out,
-    border-width 0.3s ease-in-out; */
+  transition: box-shadow 0.3s ease-in-out;
 }
 .dark #header.scroll > div:first-child,
 #header.scroll.dark > div:first-child {
   @apply bg-[#030621e6]/80 border-b border-gray-500/20;
   box-shadow: none;
-  /* transition:
-    border-color 0.3s ease-in-out,
-    border-width 0.3s ease-in-out; */
+  transition: border-width 0.3s ease-in-out;
 }
 /* #header.scroll > div:last-child {
   @apply py-3;

--- a/src/pages/materials/infografics.astro
+++ b/src/pages/materials/infografics.astro
@@ -54,7 +54,7 @@ const metadata = {
     showSearch={true}
     targetId="infografics-list"
     classes={{
-      container: 'py-0 lg:py-0 md:py-0 xl:py-[0px] mb-8 xl:mb-[32px]',
+      container: 'py-0 lg:py-0 md:py-0 xl:py-[0px] xl:mb-0',
     }}
   />
 

--- a/src/pages/materials/videos-and-podcasts.astro
+++ b/src/pages/materials/videos-and-podcasts.astro
@@ -54,7 +54,7 @@ const metadata = {
     showSearch={true}
     targetId="videos-and-podcasts-list"
     classes={{
-      container: 'py-0 lg:py-0 md:py-0 xl:py-[0px] mb-8 xl:mb-[32px]',
+      container: 'py-0 lg:py-0 md:py-0 xl:py-[0px] xl:mb-0',
     }}
   />
 

--- a/src/pages/people/collaborators.astro
+++ b/src/pages/people/collaborators.astro
@@ -72,7 +72,7 @@ const metadata = {
     title="Impactful Partnerships in Action"
     subtitle="Our collaborative achievements showcase the power of working together to advance children's health research."
     classes={{
-      container: 'pb-0 lg:pt-0 lg:pb-0 md:pt-0 md:pb-0',
+      container: 'pb-0 md:py-0 lg:py-0 xl:py-0',
     }}
     image={{
       src: imgNovo,
@@ -117,7 +117,7 @@ const metadata = {
     }}
     imageText="Knowledge exchange in action: Engaging discussions with international experts strengthen our research network"
     classes={{
-      container: 'pt-0 md:py-16 lg:py-20 xl:py-[80px]',
+      container: 'pt-0 md:pb-16 md:pt-0 lg:pb-20 lg:pt-0 xl:pb-[80px] xl:pt-0',
     }}
     items={[
       {


### PR DESCRIPTION
# Pull Request

## 📝 Description
Refined header styling and spacing in materials and people pages for improved UI consistency

### What changed?
- Updated header transition effects in `tailwind.css`:
  - Added box-shadow transition for light mode
  - Simplified transition properties for dark mode
  - Removed commented-out code and unnecessary border styles
- Adjusted spacing in materials pages:
  - Modified container margin classes in infographics and videos-and-podcasts pages
  - Replaced `mb-8 xl:mb-[32px]` with `xl:mb-0` for more consistent spacing
- Improved layout in collaborators page:
  - Simplified container padding classes for better responsiveness
  - Enhanced spacing consistency between sections

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing