### PR TITLE
refactor: fix theme toggle styling and remove unused header elements

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -58,7 +58,7 @@
   top: 70px;
   left: 0;
   right: 0;
-  bottom: 70px !important;
+  bottom: 0px !important;
   padding: 0 5px;
 }
 
@@ -152,7 +152,6 @@
   --trans-timing-out: cubic-bezier(0.05, 0.76, 0.06, 0.86);
 }
 .switch {
-  margin: auto;
   position: relative;
 }
 .switch__icon,
@@ -162,7 +161,7 @@
 .switch__icon {
   position: absolute;
   top: 0.375em;
-  right: -2.625em;
+  right: -2.625em; /* This positions the icon relative to the switch */
   width: 0.75em;
   height: 0.75em;
   transition:

--- a/src/components/common/ToggleTheme.astro
+++ b/src/components/common/ToggleTheme.astro
@@ -9,8 +9,8 @@ const currentPath = Astro.url.pathname;
 
 {
   currentPath !== '/non-academic' && (
-    <div class="group relative">
-      <label class="switch">
+    <div class="group relative w-12">
+      <label class="switch text-xs xs:text-sm sm:text-base md:text-base">
         <input data-aw-toggle-color-scheme class="switch__input" type="checkbox" role="switch" />
         <svg class="switch__icon switch__icon--light" viewBox="0 0 12 12" width="12px" height="12px" aria-hidden="true">
           <g fill="none" stroke="#fff" stroke-width="1" stroke-linecap="round">

--- a/src/components/widgets/Header.astro
+++ b/src/components/widgets/Header.astro
@@ -2,10 +2,8 @@
 import ToggleMenu from '~/components/common/ToggleMenu.astro';
 import ToggleTheme from '~/components/common/ToggleTheme.astro';
 import Logo from '~/components/Logo.astro';
-import Button from '~/components/ui/Button.astro';
 import AnimatedChildSvg from '~/components/widgets/AnimatedChildSvg.astro';
 import HeaderNavigation from '~/components/widgets/HeaderNavigation.astro';
-import type { CallToAction } from '~/types';
 import { getHomePermalink, getPermalink, trimSlash } from '~/utils/permalinks';
 import type { ImageMetadata } from 'astro';
 import { Icon } from 'astro-icon/components';
@@ -31,7 +29,6 @@ export interface Props {
   id?: string;
   links?: Array<MenuLink>;
   classes?: Record<string, string>;
-  actions?: Array<CallToAction>;
   isSticky?: boolean;
   isDark?: boolean;
   isFullWidth?: boolean;
@@ -42,7 +39,6 @@ export interface Props {
 const {
   id = 'header',
   links = [],
-  actions = [],
   isSticky = false,
   isDark = false,
   isFullWidth = false,
@@ -99,7 +95,7 @@ const { nav: navClass = '' } = classes;
       )}
       aria-label="Main navigation"
     >
-      <div class="flex justify-start py-2 px-6 lg:hidden">
+      <div class="flex justify-start py-2 px-6 xl:py-[8px] xl:px-[24px] lg:hidden">
         {showToggleTheme && <ToggleTheme />}
       </div>
       <ul
@@ -125,9 +121,9 @@ const { nav: navClass = '' } = classes;
                     <div class="flex items-center ">
                       <Icon
                         name="tabler:chevron-down"
-                        class="w-5 h-5 mr-2 text-white transition-transform duration-200 lg:hidden mobile-chevron"
+                        class="w-5 h-5 mr-2 text-black dark:text-white transition-transform duration-200 lg:hidden mobile-chevron"
                       />
-                      <span class="font-bold lg:font-normal ">
+                      <span class="font-bold lg:font-normal">
                         {text}
                         <Icon
                           name="tabler:chevron-down"
@@ -195,20 +191,6 @@ const { nav: navClass = '' } = classes;
         <div class="hidden lg:flex">
           {showToggleTheme && <ToggleTheme />}
         </div>
-        {
-          actions?.length ? (
-            <span class="ml-4 xl:ml-[16px] rtl:ml-0 rtl:mr-4">
-              {actions.map((btnProps) => (
-                <Button
-                  {...btnProps}
-                  class="ml-2 xl:ml-[8px] py-2.5 xl:py-[10px] px-5 xl:px-[24px] font-semibold shadow-none text-sm w-auto"
-                />
-              ))}
-            </span>
-          ) : (
-            ''
-          )
-        }
       </div>
     </div>
   </div>

--- a/src/layouts/LandingLayout.astro
+++ b/src/layouts/LandingLayout.astro
@@ -17,17 +17,7 @@ const { metadata } = Astro.props;
   </Fragment>
   <Fragment slot="header">
     <slot name="header">
-      <Header
-        links={headerData?.links[2] ? [headerData.links[2]] : undefined}
-        actions={[
-          {
-            text: 'Download',
-            href: 'https://github.com/onwidget/astrowind',
-          },
-        ]}
-        showToggleTheme
-        position="right"
-      />
+      <Header links={headerData?.links[2] ? [headerData.links[2]] : undefined} showToggleTheme position="right" />
     </slot>
   </Fragment>
   <slot />


### PR DESCRIPTION
# Pull Request

## 📝 Description
UI improvements for theme toggle and layout adjustments

### What changed?
- Fixed bottom positioning of content by changing `bottom: 70px` to `bottom: 0px`
- Removed unnecessary margin from theme switch
- Added explanatory comment for switch icon positioning
- Improved theme toggle responsiveness with width and text size classes
- Enhanced header layout with better padding in mobile view
- Fixed text color in mobile navigation to ensure proper contrast in dark mode
- Removed unused Button import and actions prop from Header component
- Simplified Header component in LandingLayout by removing unnecessary download action

## 📌 Additional Notes
These changes improve the overall UI consistency and responsiveness of the theme toggle and header components.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [x] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing