### PR TITLE
refactor: remove PI redirect and retain canonical  to andrew-agbaje

### DIFF
--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -35,7 +35,7 @@ export const headerData: { links: Array<MenuLink> } = {
         },
         {
           text: 'Principal Investigator Andrew Agbaje',
-          href: getPermalink('/people/principal-investigator'),
+          href: getPermalink('/people/andrew-agbaje'),
           icon: 'tabler:user-circle',
           image: {
             src: imgAndrew,

--- a/src/pages/people/principal-investigator.astro
+++ b/src/pages/people/principal-investigator.astro
@@ -16,7 +16,6 @@ const metadata = {
     'Prof. Andrew Agbaje leads the urFIT-child group, advancing global research on pediatric health, fitness, and waist to height ratio (WHtR).',
   ignoreTitleTemplate: true,
   canonical: '/people/andrew-agbaje',
-  redirect: '/people/andrew-agbaje',
   openGraph: {
     title: 'The Official Website of Prof. Andrew Agbaje',
     description:


### PR DESCRIPTION
# Pull Request

## 📝 Description
Updated the navigation link for Prof. Andrew Agbaje's profile page and removed redundant redirect property.

### What changed?
- Changed the navigation link in `headerData` from `/people/principal-investigator` to `/people/andrew-agbaje`
- Removed the unnecessary `redirect` property from the principal-investigator page metadata while keeping the canonical URL

## 📌 Additional Notes
This change ensures consistent URL structure for the principal investigator's profile page.

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [x] ⚠️ No new warnings or errors are generated

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the navigation link for "Principal Investigator Andrew Agbaje" to use a new URL path.
  - Removed a redirect from the previous principal investigator page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->