### PR TITLE
fix: remove w-full class and update image responsive sizes

### DIFF
--- a/src/components/widgets/Hero.astro
+++ b/src/components/widgets/Hero.astro
@@ -101,7 +101,7 @@ const { titleClass = '' } = classes;
                     {image.link ? (
                       <a href={image.link.href} target={image.link.target} rel={image.link.rel}>
                         <Image
-                          class={twMerge('mx-auto rounded-md w-full', image?.class ?? '')}
+                          class={twMerge('mx-auto rounded-md', image?.class ?? '')}
                           widths={[400, 768, 1024, 2040]}
                           sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
                           loading="eager"
@@ -113,9 +113,9 @@ const { titleClass = '' } = classes;
                       </a>
                     ) : (
                       <Image
-                        class={twMerge('mx-auto rounded-md w-full', image?.class ?? '')}
-                        widths={[400, 768, 1024, 2040]}
-                        sizes="(max-width: 767px) 400px, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
+                        class={twMerge('mx-auto rounded-md', image?.class ?? '')}
+                        widths={[320, 400, 768, 1024, 2040]}
+                        sizes="(max-width: 767px) 100vw, (max-width: 1023px) 768px, (max-width: 2039px) 1024px, 2040px"
                         loading="eager"
                         decoding="async"
                         objectPosition={image?.objectPosition || 'top top'}


### PR DESCRIPTION
# Pull Request

## 📝 Description
Improved image responsiveness in the Hero component by adjusting image classes and responsive sizing parameters.

### What changed?
- Removed `w-full` class from hero images to allow for more natural image sizing
- Added a new `320px` width breakpoint for smaller devices
- Updated the `sizes` attribute to use `100vw` for mobile screens instead of fixed `400px` width

## 📌 Additional Notes
These changes should improve how hero images display across different device sizes, particularly on mobile.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [x] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated image styling in the Hero widget by removing the full-width constraint for improved layout flexibility.

* **Bug Fixes**
  * Improved responsive image behavior for standalone images, ensuring better display on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->