### PR TITLE
fix: use imageText2 instead of imageText for aria-label in Features5

### DIFF
--- a/src/components/widgets/Features5.astro
+++ b/src/components/widgets/Features5.astro
@@ -100,7 +100,7 @@ const {
           image2 && (
             <figure class="relative mx-auto max-w-4xl xl:max-w-[896px]">
               {typeof image2 === 'string' ? (
-                <div class="image-container" role="img" aria-label={imageText || 'Content image'}>
+                <div class="image-container" role="img" aria-label={imageText2 || 'Content image'}>
                   <Fragment set:html={image2} />
                 </div>
               ) : (


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fixed incorrect aria-label in Features5 component by using `imageText2` variable instead of `imageText` for the second image.

### What changed?
- Updated the aria-label attribute in the second image container to use the correct `imageText2` variable instead of `imageText`

## 📌 Additional Notes
This improves accessibility by ensuring the second image has the correct aria label when provided.

## 🔗 Related Issues
🔄 Closes #

## 🔍 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (would cause existing functionality to not work)
- [ ] 📚 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] 📦 Dependency update
- [ ] 🧪 Test update
- [ ] 🔧 Configuration change

## ✅ Checklist
### Code Quality
- [x] 👀 I have performed a self-review
- [ ] 💬 I have added necessary comments
- [x] ⚠️ No new warnings or errors are generated
- [ ] ⚡ I have added/updated tests

### Git Hygiene
- [x] 🔍 My commits are small and have clear messages
- [x] 🔀 I have rebased on the latest main branch
- [x] 🧩 This PR is small and focused on a single change

## 🧪 Testing
- [x] 👉 Manual testing